### PR TITLE
Resolved: linker error when trying to link with nvidia riva protocol …

### DIFF
--- a/files/Makefile.am.extra
+++ b/files/Makefile.am.extra
@@ -425,8 +425,10 @@ NVIDIA_GENS_PATH = libs/riva-asr-grpc-api/stubs/
 nodist_libfreeswitch_libnvidiaapis_la_SOURCES = \
 libs/riva-asr-grpc-api/stubs/riva/proto/riva_asr.pb.cc \
 libs/riva-asr-grpc-api/stubs/riva/proto/riva_audio.pb.cc \
+libs/riva-asr-grpc-api/stubs/riva/proto/riva_common.pb.cc \
 libs/riva-asr-grpc-api/stubs/riva/proto/riva_asr.grpc.pb.cc \
-libs/riva-asr-grpc-api/stubs/riva/proto/riva_audio.grpc.pb.cc 
+libs/riva-asr-grpc-api/stubs/riva/proto/riva_audio.grpc.pb.cc \
+libs/riva-asr-grpc-api/stubs/riva/proto/riva_common.grpc.pb.cc
 
 libfreeswitch_libnvidiaapis_la_CPPFLAGS = -I/usr/local/include -I$(NVIDIA_GENS_PATH) -std=c++17  -pthread
 


### PR DESCRIPTION
Fixed docker build error. Linker failed to link to nvidia riva protocol buffer stubs.